### PR TITLE
Replace bare except clauses with specific exception types

### DIFF
--- a/lib/machine/cpu.py
+++ b/lib/machine/cpu.py
@@ -89,7 +89,7 @@ class CPU:
 				max_freq = cpu_freq_helper(entry, "max")
 				try:
 					base_freq = round(get(path(entry, "cpufreq/base_frequency"), isint=True) / 1000)
-				except:
+				except (TypeError, ValueError, OSError):
 					base_freq = None
 
 				freqs[f] = {
@@ -160,7 +160,7 @@ def cpu_freq_helper(cpu_path: str, type: str):
 
 	try:
 		freq = round(freq / 1000)
-	except:
+	except (TypeError, ValueError):
 		freq = None
 
 	return freq

--- a/lib/machine/network.py
+++ b/lib/machine/network.py
@@ -40,6 +40,6 @@ def get_default_iface_name_linux():
 					continue
 				interface = iface
 				break
-			except:
+			except (ValueError, IndexError):
 				continue
 	return interface


### PR DESCRIPTION
Bare except clauses silently swallow all exceptions including KeyboardInterrupt and SystemExit, which can mask bugs and make debugging difficult. This change replaces them with specific exception types that are expected for each operation.

Changes:
- cpu.py:92: Catch TypeError, ValueError, OSError for base_freq calc
- cpu.py:163: Catch TypeError, ValueError for frequency division
- network.py:43: Catch ValueError, IndexError for route parsing

Security impact:
- Prevents silent failure masking potential issues
- Improves error traceability and auditability
- Allows unexpected exceptions to propagate for proper handling