### PR TITLE
Use context managers for file handle management in config

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -117,7 +117,8 @@ class Config:
 		path = path if path else "config.json"
 		if not self.config["no_config"] and path:
 			try:
-				config_file = json.loads(open(path, "r").read())
+				with open(path, "r") as f:
+					config_file = json.loads(f.read())
 				for section in config_file:
 					for key in config_file[section]:
 						CONFIG_DEFAULT[section][key]["value"] = config_file[section][key]
@@ -135,7 +136,6 @@ class Config:
 				with open(path, "w") as file:
 					print(f"Config file not found. Saving default configuration to {path}...")
 					file.write(json.dumps(config_file, indent=4))
-					file.close()
 
 
 		# Fallback values from default config


### PR DESCRIPTION
Replace unsafe open().read() pattern with context manager to ensure proper file handle cleanup. Also remove redundant file.close() call inside existing with-block.

Changes:
- Line 120: Wrap config file read in context manager
- Line 138: Remove redundant close() inside with-block

Security impact:
- Prevents file descriptor leaks under error conditions
- Ensures proper resource cleanup on exceptions
- Follows Python best practices for file operations