### PR TITLE
Remove redundant file close inside context manager

### DIFF
--- a/lib/machine/cpu.py
+++ b/lib/machine/cpu.py
@@ -133,8 +133,6 @@ class CPU:
 def get_stat():
 	with open('/proc/stat') as f:
 		fields = [float(column) for column in f.readline().strip().split()[1:]]
-		f.close()
-
 	return fields
 
 


### PR DESCRIPTION
The with-statement automatically closes the file when exiting the block, making the explicit f.close() call unnecessary and potentially confusing.

Changes:
- Remove f.close() from get_stat() function
- File handle now properly managed by context manager alone

Code quality impact:
- Cleaner, more idiomatic Python
- Reduces confusion about file handle lifecycle
- Consistent with Python context manager semantics