### PR TITLE
Set explicit file permissions when creating config file

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 from os import environ
 
 
@@ -132,10 +133,10 @@ class Config:
 						config_file[section] = {}
 					config_file[section][key] = CONFIG_DEFAULT[section][key]["value"]
 
-				with open(path, "w") as file:
-					print(f"Config file not found. Saving default configuration to {path}...")
+				print(f"Config file not found. Saving default configuration to {path}...")
+				fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+				with os.fdopen(fd, "w") as file:
 					file.write(json.dumps(config_file, indent=4))
-					file.close()
 
 
 		# Fallback values from default config


### PR DESCRIPTION
Use os.open() with explicit mode 0o600 (owner read/write only) instead of default open() which inherits permissions from umask. This prevents the config file from being world-readable by default.

Changes:
- Add os import for low-level file operations
- Replace open(path, "w") with os.open() using O_CREAT | O_TRUNC
- Set permissions to 0o600 (rw-------)
- Remove redundant file.close() inside with-block

Security impact:
- Config file protected from other users on multi-user systems
- Prevents information disclosure of server configuration
- Follows principle of least privilege for file permissions