### PR TITLE
Remove duplicate element ID in theme settings

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -206,7 +206,7 @@
 							<i>contrast</i>
 							<div class="text">
 								<div class="name">Use platform theme</div>
-								<div class="value" id="main-storage">App will sync its dark theme with your device's one</div>
+								<div class="value">App will sync its dark theme with your device's one</div>
 							</div>
 							<i class="checkbox"></i>
 						</div>


### PR DESCRIPTION
Remove erroneous id="main-storage" from auto-theme description element. This ID was duplicated from the storage section and caused invalid HTML. The ID is not needed for this element as it contains static text.

Code quality impact:
- Valid HTML structure
- Predictable getElementById behavior
- Fixes W3C validation error