### PR TITLE
Fix implicit global variable in screen iteration

### DIFF
--- a/html/js/main.js
+++ b/html/js/main.js
@@ -42,7 +42,7 @@ function goto(target, updateHash = true) {
 	if (updateHash) window.location.hash = target
 	let toShow = get(target)
 	let screens = getClasses("screen")
-	for (screen of screens) {
+	for (let screen of screens) {
 		if (toShow == screen) screen.classList.remove("hidden")
 		else screen.classList.add("hidden")
 	}


### PR DESCRIPTION
Add missing 'let' declaration in for-of loop to prevent creating an implicit global variable 'screen'. This was overwriting window.screen and could cause conflicts with other code relying on that property.

Code quality impact:
- Prevents global namespace pollution
- Avoids overwriting built-in window.screen property
- Follows JavaScript strict mode best practices