### PR TITLE
Add allowlist validation for URL hash navigation

### DIFF
--- a/html/js/main.js
+++ b/html/js/main.js
@@ -1,3 +1,5 @@
+const VALID_SCREENS = ['main', 'cpu', 'memory', 'storage', 'network', 'host', 'theme']
+
 window.addEventListener("load", () => {
 	update()
 	hashchange()
@@ -24,7 +26,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 function hashchange() {
 	let hash = window.location.hash.slice(1)
-	if (hash == "") hash = "main"
+	if (!VALID_SCREENS.includes(hash)) hash = "main"
 	goto(hash, false)
 }
 window.addEventListener("hashchange", hashchange)


### PR DESCRIPTION
Validate URL hash against explicit list of valid screen IDs before navigation. Invalid or unknown hashes now redirect to main screen instead of attempting to find a non-existent element.

Changes:
- Add VALID_SCREENS constant with allowed navigation targets
- Replace empty string check with allowlist validation

Security impact:
- Prevents navigation to arbitrary element IDs
- Explicit allowlist follows principle of least privilege
- Predictable behavior for malformed URLs