### PR TITLE
Remove inline event handlers for CSP compliance

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -22,14 +22,14 @@
 				<div class="value" id="main-device-name">N/A</div>
 			</div>
 			<div class="center titlebar">
-				<button onclick="goto('theme')">
+				<button data-goto="theme">
 					<i>palette</i>
 					<p>Theme</p>
 				</button>
 			</div>
 			<div class="contents">
 				<div class="list">
-					<div class="item clickable" onclick="goto('cpu')">
+					<div class="item clickable" data-goto="cpu">
 						<i>memory</i>
 						<div class="text">
 							<div class="name">CPU</div>
@@ -37,7 +37,7 @@
 						</div>
 						<i class="arrow"></i>
 					</div>
-					<div class="item clickable" onclick="goto('memory')">
+					<div class="item clickable" data-goto="memory">
 						<i>memory_alt</i>
 						<div class="text">
 							<div class="name">Memory</div>
@@ -45,7 +45,7 @@
 						</div>
 						<i class="arrow"></i>
 					</div>
-					<div class="item clickable" onclick="goto('storage')">
+					<div class="item clickable" data-goto="storage">
 						<i>hard_drive</i>
 						<div class="text">
 							<div class="name">Storage</div>
@@ -53,7 +53,7 @@
 						</div>
 						<i class="arrow"></i>
 					</div>
-					<div class="item clickable" onclick="goto('network')">
+					<div class="item clickable" data-goto="network">
 						<i>settings_ethernet</i>
 						<div class="text">
 							<div class="name">Network</div>
@@ -61,7 +61,7 @@
 						</div>
 						<i class="arrow"></i>
 					</div>
-					<div class="item clickable" onclick="goto('host')">
+					<div class="item clickable" data-goto="host">
 						<i>cloud</i>
 						<div class="text">
 							<div class="name">Host</div>
@@ -164,7 +164,7 @@
 			<div class="contents">
 				<div class="center">
 					<div class="themes">
-						<div class="theme light" onclick="selectTheme(true)">
+						<div class="theme light" data-theme="light">
 							<div class="preview">
 								<div class="box">
 									<i>chevron_right</i>
@@ -174,7 +174,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="theme dark" onclick="selectTheme(false)">
+						<div class="theme dark" data-theme="dark">
 							<div class="preview">
 								<div class="box">
 									<i>chevron_right</i>
@@ -202,7 +202,7 @@
 
 				<div class="center">
 					<div class="list" style="width: 100%;">
-						<div class="item clickable" id="autoDarkSwitch" onclick="setAutoTheme()">
+						<div class="item clickable" id="autoDarkSwitch">
 							<i>contrast</i>
 							<div class="text">
 								<div class="name">Use platform theme</div>

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -10,6 +10,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () 
 
 document.addEventListener("DOMContentLoaded", () => {
 	loadBackButtons()
+	loadNavigationButtons()
 	loadThemePicker()
 	try {
 		let accent = localStorage.getItem("statusapp-accent")
@@ -32,9 +33,16 @@ window.addEventListener("hashchange", hashchange)
 function loadBackButtons() {
 	let buttons = getClasses("back")
 	for (let button of buttons) {
-		button.onclick = () => {
-			goBack()
-		}
+		button.addEventListener("click", goBack)
+	}
+}
+
+function loadNavigationButtons() {
+	let navButtons = document.querySelectorAll("[data-goto]")
+	for (let button of navButtons) {
+		button.addEventListener("click", () => {
+			goto(button.dataset.goto)
+		})
 	}
 }
 
@@ -58,6 +66,18 @@ function loadThemePicker() {
 		accent.addEventListener("click", () => {
 			selectAccent(accent.className)
 		})
+	}
+	// Theme selection buttons
+	let themeButtons = document.querySelectorAll("[data-theme]")
+	for (let button of themeButtons) {
+		button.addEventListener("click", () => {
+			selectTheme(button.dataset.theme === "light")
+		})
+	}
+	// Auto dark mode switch
+	let autoSwitch = document.getElementById("autoDarkSwitch")
+	if (autoSwitch) {
+		autoSwitch.addEventListener("click", setAutoTheme)
 	}
 	if (!localStorage.getItem("statusapp-light")) {
 		document.querySelector("#autoDarkSwitch .checkbox").classList.add("enabled")


### PR DESCRIPTION
Move all inline onclick handlers to external JavaScript using addEventListener. This change is required for Content Security Policy compliance (see security/js-content-security-policy branch).

CSP blocks inline JavaScript execution by default. To enable strict CSP without 'unsafe-inline' for scripts, all event handlers must be registered via JavaScript.

Changes to index.html:
- Replace onclick="goto(...)" with data-goto="..." attributes
- Replace onclick="selectTheme(...)" with data-theme="..." attributes
- Remove onclick="setAutoTheme()" from autoDarkSwitch

Changes to main.js:
- Add loadNavigationButtons() for data-goto handlers
- Update loadThemePicker() to register theme button handlers
- Register autoDarkSwitch click handler
- Use addEventListener instead of onclick assignment

Security impact:
- Enables strict Content Security Policy
- Eliminates inline script execution vectors
- Follows security best practices for event handling