### PR TITLE
Remove raw_html option to eliminate XSS vector

### DIFF
--- a/html/js/utils.js
+++ b/html/js/utils.js
@@ -99,10 +99,7 @@ function mkDiv(args, icon) {
 	let div = document.createElement((icon) ? "i" : "div")
 	if (args.id) div.id = args.id
 	if (args.className) div.className = args.className
-	if (args.text) {
-		if (args.raw_html) div.innerHTML = args.text
-		else div.innerText = args.text
-	}
+	if (args.text) div.innerText = args.text
 	return div;
 }
 


### PR DESCRIPTION
## Summary
- Remove the `raw_html` option from the `mkDiv()` function in `utils.js`
- This eliminates a potential XSS attack vector where HTML could be injected
- All text content is now safely rendered via `innerText` only

## Security Impact
- **OWASP A7:2017** Cross-Site Scripting (XSS) prevention
- Removes latent vulnerability that could be exploited if server data was ever passed with `raw_html: true`
