### PR TITLE
Add Content Security Policy meta tag

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -3,6 +3,7 @@
 <head>
 	<title>Status</title>
 	<meta charset="utf-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; form-action 'self'">
 	<meta name="theme-color" content="#000">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<link href="img/icon.png" rel="icon">


### PR DESCRIPTION
## Summary
- Add CSP meta tag to `index.html` with restrictive policy
- Policy: `default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; form-action 'self'`

## Security Impact
- **OWASP A6:2017** Security Misconfiguration prevention
- Provides browser-side XSS mitigation
- Prevents clickjacking via `frame-ancestors 'none'`
- Restricts resource loading to same origin

## Dependencies
- Should be merged together with PR #39 (Remove inline event handlers) for full CSP compliance
- Inline `onclick` handlers were moved to external JavaScript in PR #39
