### PR TITLE
Add Docker container monitoring page

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ docker-compose up -d
 App should be available on [localhost:9090](http://localhost:9090).
 
 
+## :whale: Docker Monitoring
+
+Status can monitor your Docker containers and display their status, CPU and memory usage.
+
+**Features:**
+- Container count (running/stopped) on main screen
+- Detailed container list with resource usage
+- Auto-hides when Docker is not available
+
+**Requirements:**
+- Docker socket must be accessible (mounted in docker-compose.yml by default)
+- Can be disabled via `--docker-disable` or `STATUS_DOCKER_DISABLE=true`
+
+| Config file          | Environment variable      | Command line argument |
+|----------------------|---------------------------|-----------------------|
+| `docker.disable`     | `STATUS_DOCKER_DISABLE`   | `--docker-disable`    |
+
+
 ## :wrench: Configuration
 
 Status can be configured in multiple ways:
@@ -89,6 +107,7 @@ Config keys are named slightly differently under different ways of configuration
 | **Example #1** | `server.port`       | `STATUS_SERVER_PORT`        | `--server-port`       |
 | **Example #2** | `server.address`    | `STATUS_SERVER_ADDRESS`     | `--server-address`    |
 | **Example #3** | `misc.debug`        | `STATUS_MISC_DEBUG`         | `--misc-debug`        |
+| **Example #4** | `docker.disable`    | `STATUS_DOCKER_DISABLE`     | `--docker-disable`    |
 
 Command line offers `--config` (or `-c`) to set custom config location.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,6 @@ services:
       - "/mnt:/mnt:ro"
       - "/media:/media:ro"
       - "/run/media:/run/media:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
     network_mode: "host"
     restart: "unless-stopped"

--- a/html/index.html
+++ b/html/index.html
@@ -69,6 +69,14 @@
 						</div>
 						<i class="arrow"></i>
 					</div>
+					<div class="item clickable" id="main-docker-item" onclick="goto('docker')" style="display: none;">
+						<i>deployed_code</i>
+						<div class="text">
+							<div class="name">Docker</div>
+							<div class="value" id="main-docker">N/A</div>
+						</div>
+						<i class="arrow"></i>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -150,6 +158,20 @@
 			</div>
 			<div class="contents">
 				<div class="list" id="host-list"></div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Docker screen -->
+	<div class="screen hidden" id="docker">
+		<div class="wrapper">
+			<div class="header">
+				<i class="back"></i>
+				<div class="title">Docker</div>
+			</div>
+			<div class="contents">
+				<div class="bar" id="docker-bar"></div>
+				<div class="list" id="docker-list"></div>
 			</div>
 		</div>
 	</div>

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -125,6 +125,7 @@ function parseData(resp) {
 		updateStorage(data.storage)
 		updateNet(data_prev.network, data.network)
 		updateHost(data.host)
+		updateDocker(data.docker)
 		data_prev = data
 	}
 	catch (e) {

--- a/html/js/parser.js
+++ b/html/js/parser.js
@@ -167,3 +167,61 @@ function updateHost(host) {
 	mkItem("host-list", "memory", "App memory", parseSize(host.app_memory, "B"))
 	mkItem("host-list", "speed", "Load averages", host.loadavg.join(", "))
 }
+
+
+var docker_last = []
+function updateDocker(docker) {
+	let dockerItem = get("main-docker-item")
+
+	// Hide Docker menu item if not available
+	if (!docker || !docker.available) {
+		dockerItem.style.display = "none"
+		return
+	}
+
+	// Show Docker menu item
+	dockerItem.style.display = ""
+
+	// Update main screen summary
+	let summary = `${docker.running} running`
+	if (docker.stopped > 0) {
+		summary += `, ${docker.stopped} stopped`
+	}
+	set("main-docker", summary)
+
+	// Update bar
+	let progress = docker.total > 0 ? docker.running / docker.total : 0
+	mkBar("docker-bar",
+		progress, docker.running, `of ${docker.total}`,
+		`${docker.total} container${s(docker.total)} total`,
+		`${docker.running} running, ${docker.stopped} stopped`
+	)
+
+	// Update container list
+	for (let container of docker.containers) {
+		let stateIcon = container.state === "running" ? "play_circle" : "stop_circle"
+		let values = [container.status]
+
+		if (container.cpu) {
+			values.push(`CPU: ${container.cpu}, Mem: ${container.memory_percent}`)
+		}
+		if (container.image) {
+			values.push(`Image: ${container.image}`)
+		}
+
+		mkItem("docker-list", stateIcon, container.name, values, container.id)
+	}
+
+	// Clean removed containers
+	if (docker_last.length > 0) {
+		let currentIds = docker.containers.map(c => c.id)
+		for (let lastContainer of docker_last) {
+			if (!currentIds.includes(lastContainer.id)) {
+				let elem = document.getElementById(`docker-list-${lastContainer.id}`)
+				if (elem) elem.remove()
+			}
+		}
+	}
+
+	docker_last = docker.containers
+}

--- a/html/js/parser.js
+++ b/html/js/parser.js
@@ -175,9 +175,12 @@ function updateDocker(docker) {
 
 	// Hide Docker menu item if not available
 	if (!docker || !docker.available) {
-		dockerItem.style.display = "none"
+		if (dockerItem) dockerItem.style.display = "none"
 		return
 	}
+
+	// If Docker HTML elements don't exist yet, skip
+	if (!dockerItem) return
 
 	// Show Docker menu item
 	dockerItem.style.display = ""

--- a/lib/config.py
+++ b/lib/config.py
@@ -62,11 +62,10 @@ CONFIG_DEFAULT = {
 		}
 	},
 	"docker": {
-		"enabled": {
-			"value": True,
-			"short": "D",
+		"disable": {
+			"value": False,
 			"no_value": True,
-			"desc": "enable Docker container monitoring"
+			"desc": "disable Docker container monitoring"
 		},
 	},
 	"misc": {

--- a/lib/config.py
+++ b/lib/config.py
@@ -61,6 +61,14 @@ CONFIG_DEFAULT = {
 			"value": []
 		}
 	},
+	"docker": {
+		"enabled": {
+			"value": True,
+			"short": "D",
+			"no_value": True,
+			"desc": "enable Docker container monitoring"
+		},
+	},
 	"misc": {
 		"debug": {
 			"value": False,

--- a/lib/machine/__init__.py
+++ b/lib/machine/__init__.py
@@ -3,6 +3,7 @@ from .memory import Memory
 from .storage import Storage
 from .network import Network
 from .host import Host
+from .docker import Docker
 
 
 class Machine:
@@ -13,6 +14,7 @@ class Machine:
 		self.storage = Storage()
 		self.network = Network()
 		self.host = Host()
+		self.docker = Docker()
 
 	async def get_full_info(self):
 		return {
@@ -20,5 +22,6 @@ class Machine:
 			"memory": self.memory.get_usage(),
 			"storage": self.storage.get_usage(),
 			"network": self.network.get_net(),
-			"host": self.host.get_host()
+			"host": self.host.get_host(),
+			"docker": self.docker.get_info()
 		}

--- a/lib/machine/docker.py
+++ b/lib/machine/docker.py
@@ -89,7 +89,7 @@ class Docker:
 
 	def get_info(self):
 		"""Get Docker information summary."""
-		if not config.get("docker", "enabled"):
+		if config.get("docker", "disable"):
 			return None
 		if not self.is_available():
 			return None

--- a/lib/machine/docker.py
+++ b/lib/machine/docker.py
@@ -1,6 +1,8 @@
 import subprocess
 import json
 
+from lib.config import config
+
 
 class Docker:
 
@@ -87,6 +89,8 @@ class Docker:
 
 	def get_info(self):
 		"""Get Docker information summary."""
+		if not config.get("docker", "enabled"):
+			return None
 		if not self.is_available():
 			return None
 

--- a/lib/machine/docker.py
+++ b/lib/machine/docker.py
@@ -1,0 +1,118 @@
+import subprocess
+import json
+
+
+class Docker:
+
+	@staticmethod
+	def is_available():
+		"""Check if Docker is installed and accessible."""
+		try:
+			result = subprocess.run(
+				["docker", "info"],
+				capture_output=True,
+				timeout=5
+			)
+			return result.returncode == 0
+		except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+			return False
+
+	@staticmethod
+	def get_containers():
+		"""Get list of all containers with their details."""
+		try:
+			result = subprocess.run(
+				["docker", "ps", "-a", "--format", "{{json .}}"],
+				capture_output=True,
+				text=True,
+				timeout=10
+			)
+			if result.returncode != 0:
+				return []
+
+			containers = []
+			for line in result.stdout.strip().split("\n"):
+				if not line:
+					continue
+				try:
+					container = json.loads(line)
+					containers.append({
+						"id": container.get("ID", ""),
+						"name": container.get("Names", ""),
+						"image": container.get("Image", ""),
+						"status": container.get("Status", ""),
+						"state": container.get("State", ""),
+						"ports": container.get("Ports", ""),
+						"created": container.get("CreatedAt", "")
+					})
+				except json.JSONDecodeError:
+					continue
+			return containers
+		except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+			return []
+
+	@staticmethod
+	def get_stats():
+		"""Get resource usage statistics for running containers."""
+		try:
+			result = subprocess.run(
+				["docker", "stats", "--no-stream", "--format", "{{json .}}"],
+				capture_output=True,
+				text=True,
+				timeout=15
+			)
+			if result.returncode != 0:
+				return []
+
+			stats = []
+			for line in result.stdout.strip().split("\n"):
+				if not line:
+					continue
+				try:
+					stat = json.loads(line)
+					stats.append({
+						"id": stat.get("ID", ""),
+						"name": stat.get("Name", ""),
+						"cpu": stat.get("CPUPerc", "0%"),
+						"memory": stat.get("MemUsage", ""),
+						"memory_percent": stat.get("MemPerc", "0%"),
+						"net_io": stat.get("NetIO", ""),
+						"block_io": stat.get("BlockIO", "")
+					})
+				except json.JSONDecodeError:
+					continue
+			return stats
+		except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+			return []
+
+	def get_info(self):
+		"""Get Docker information summary."""
+		if not self.is_available():
+			return None
+
+		containers = self.get_containers()
+		stats = self.get_stats()
+
+		# Create stats lookup by container name
+		stats_by_name = {s["name"]: s for s in stats}
+
+		# Merge stats into container info
+		for container in containers:
+			name = container["name"]
+			if name in stats_by_name:
+				container["cpu"] = stats_by_name[name]["cpu"]
+				container["memory"] = stats_by_name[name]["memory"]
+				container["memory_percent"] = stats_by_name[name]["memory_percent"]
+				container["net_io"] = stats_by_name[name]["net_io"]
+				container["block_io"] = stats_by_name[name]["block_io"]
+
+		running = sum(1 for c in containers if c["state"] == "running")
+		stopped = len(containers) - running
+
+		return {
+			"available": True,
+			"running": running,
+			"stopped": stopped,
+			"total": len(containers),
+			"containers": containers
+		}


### PR DESCRIPTION
## Summary
Add a new Docker subpage that displays container information when Docker is available on the system.

### Features
- **Main screen**: Shows Docker menu item with running/stopped container count (hidden when Docker unavailable)
- **Docker page**: 
  - Progress bar showing running vs total containers
  - List of all containers with status, CPU/memory usage, and image name
  - Live updates every 1.5 seconds like other metrics

### Backend
- New `lib/machine/docker.py` module that queries Docker via CLI (`docker ps`, `docker stats`)
- Gracefully handles systems without Docker installed (returns `null`)
- No additional Python dependencies required

### Frontend
- Docker menu item automatically shown/hidden based on availability
- Consistent UI with existing pages (CPU, Memory, Storage, etc.)
- Container state icons: play_circle (running), stop_circle (stopped)

## Screenshots
The Docker menu item only appears when Docker is installed and accessible, making the feature transparent on systems without Docker.
<img width="798" height="756" alt="image" src="https://github.com/user-attachments/assets/a3cd06aa-191c-4994-82f0-e72a05923989" />
<img width="1014" height="696" alt="image" src="https://github.com/user-attachments/assets/69a6b165-cee4-44a8-8d75-63a03e0ebdf0" />
